### PR TITLE
Fix OpenGL platform-specific problem

### DIFF
--- a/include/Core/DebugMessageCallback.hpp
+++ b/include/Core/DebugMessageCallback.hpp
@@ -3,8 +3,6 @@
 
 #include "pch.hpp" // IWYU pragma: export
 
-#include <GL/gl.h>
-
 namespace Core {
 /**
  * @brief Callback function for OpenGL handling

--- a/include/Core/DebugMessageCallback.hpp
+++ b/include/Core/DebugMessageCallback.hpp
@@ -3,6 +3,8 @@
 
 #include "pch.hpp" // IWYU pragma: export
 
+#include <GL/gl.h>
+
 namespace Core {
 /**
  * @brief Callback function for OpenGL handling
@@ -12,9 +14,10 @@ namespace Core {
  *
  * @see https://www.khronos.org/opengl/wiki/Debug_Output
  */
-void OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
-                                GLenum severity, GLsizei length,
-                                const GLchar *message, const void *data);
+void GLAPIENTRY
+OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
+                           GLenum severity, GLsizei length,
+                           const GLchar *message, const void *data);
 } // namespace Core
 
 #endif

--- a/include/Core/DebugMessageCallback.hpp
+++ b/include/Core/DebugMessageCallback.hpp
@@ -12,10 +12,11 @@ namespace Core {
  *
  * @see https://www.khronos.org/opengl/wiki/Debug_Output
  */
-void GLAPIENTRY
-OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
-                           GLenum severity, GLsizei length,
-                           const GLchar *message, const void *data);
+void GLAPIENTRY OpenGLDebugMessageCallback(GLenum source, GLenum type,
+                                           GLuint id, // NOLINT
+                                           GLenum severity, GLsizei length,
+                                           const GLchar *message,
+                                           const void *data);
 } // namespace Core
 
 #endif

--- a/src/Core/DebugMessageCallback.cpp
+++ b/src/Core/DebugMessageCallback.cpp
@@ -3,10 +3,11 @@
 #include "Util/Logger.hpp"
 
 namespace Core {
-void GLAPIENTRY
-OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
-                           GLenum severity, GLsizei length,
-                           const GLchar *message, const void *data) {
+void GLAPIENTRY OpenGLDebugMessageCallback(GLenum source, GLenum type,
+                                           GLuint id, // NOLINT
+                                           GLenum severity, GLsizei length,
+                                           const GLchar *message,
+                                           const void *data) {
     std::string sourceString;
     std::string typeString;
     std::string severityString;

--- a/src/Core/DebugMessageCallback.cpp
+++ b/src/Core/DebugMessageCallback.cpp
@@ -1,11 +1,14 @@
 #include "Core/DebugMessageCallback.hpp"
 
+#include <GL/gl.h>
+
 #include "Util/Logger.hpp"
 
 namespace Core {
-void OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
-                                GLenum severity, GLsizei length,
-                                const GLchar *message, const void *data) {
+void GLAPIENTRY
+OpenGLDebugMessageCallback(GLenum source, GLenum type, GLuint id, // NOLINT
+                           GLenum severity, GLsizei length,
+                           const GLchar *message, const void *data) {
     std::string sourceString;
     std::string typeString;
     std::string severityString;

--- a/src/Core/DebugMessageCallback.cpp
+++ b/src/Core/DebugMessageCallback.cpp
@@ -1,7 +1,5 @@
 #include "Core/DebugMessageCallback.hpp"
 
-#include <GL/gl.h>
-
 #include "Util/Logger.hpp"
 
 namespace Core {


### PR DESCRIPTION
I got
```
E:\Workspace\practical-tools-for-simple-design\src\Core\Context.cpp(72): error C2664: 'void (GLDEBUGPROC,const void *)'
: cannot convert argument 1 from 'overloaded-function' to 'GLDEBUGPROC' [E:\Workspace\practical-tools-for-simple-design
\build\Sample.vcxproj]
```

then I found
https://www.khronos.org/opengl/wiki/Debug_Output#Examples @ https://stackoverflow.com/a/58585041

It works