### PR TITLE
Remove `SDL2main` from `Tests`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(Sample
     ${SRC_DIR}/main.cpp
 )
 target_link_libraries(Sample
+        SDL2::SDL2main
     ${DEPENDENCY_LINK_LIBRARIES}
 )
 target_include_directories(Sample SYSTEM PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_executable(Sample
     ${SRC_DIR}/main.cpp
 )
 target_link_libraries(Sample
-        SDL2::SDL2main
+    SDL2::SDL2main # IDK what happens if we don't link SDL2main
     ${DEPENDENCY_LINK_LIBRARIES}
 )
 target_include_directories(Sample SYSTEM PRIVATE

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -102,7 +102,6 @@ set(DEPENDENCY_LINK_LIBRARIES
     glew_s
 
     SDL2::SDL2-static
-    SDL2::SDL2main
     SDL2_image::SDL2_image-static
     SDL2_ttf::SDL2_ttf-static
     SDL2_mixer::SDL2_mixer-static


### PR DESCRIPTION
I need this to make tests work on Windows, since #18 has not been merged yet.

> Because on this platform, SDL2 mandates the linkage with SDL2_main, which acts as a wrapper around the actual main function. But gtest also uses some kind of wrapper around the main function, and also imposes some constraints on it.

_from [Using SDL2 with the Google Test framework (gtest) ](https://gbaudic.github.io/2021/07/14/using_sdl2_with_gtest.html)_