### PR TITLE
Misc refactor & Separate `AudioTest`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(PracticalToolsForSimpleDesign)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+if (MSVC)
+	set(TARGET_COMPILE_OPTIONS
+        /W4
+    )
+else()
+	set(TARGET_COMPILE_OPTIONS
+        -Wall -Wextra -pedantic
+    )
+endif()
 
 include(cmake/Dependencies.cmake)
 
@@ -55,7 +64,7 @@ set(TEST_DIR ${CMAKE_SOURCE_DIR}/test)
 set(TEST_FILES
     ${TEST_DIR}/SimpleTest.cpp
     ${TEST_DIR}/NotSimpleTest.cpp
-    ${TEST_DIR}/Audio.cpp
+    ${TEST_DIR}/Interactive/Audio.cpp
 )
 
 add_executable(Sample
@@ -74,15 +83,9 @@ target_include_directories(Sample PRIVATE
 target_precompile_headers(Sample PRIVATE
     include/pch.hpp
 )
-if (MSVC)
-    target_compile_options(Sample PRIVATE
-        /W4
-    )
-else()
-    target_compile_options(Sample PRIVATE
-        -Wall -Wextra -pedantic
-    )
-endif()
+target_compile_options(Sample PRIVATE
+	${TARGET_COMPILE_OPTIONS}
+)
 
 enable_testing()
 
@@ -96,23 +99,15 @@ target_link_libraries(Tests
 )
 target_include_directories(Tests SYSTEM PRIVATE
     ${DEPENDENCY_INCLUDE_DIRS}
+    lib/googletest/googletest/include
+    lib/googletest/googlemock/include
 )
 target_include_directories(Tests PRIVATE
     ${INCLUDE_DIR}
 )
-target_include_directories(Tests SYSTEM PRIVATE
-    lib/googletest/googletest/include
-    lib/googletest/googlemock/include
+target_compile_options(Tests PRIVATE
+    ${TARGET_COMPILE_OPTIONS}
 )
-if (MSVC)
-    target_compile_options(Tests PRIVATE
-        /W4
-    )
-else()
-    target_compile_options(Tests PRIVATE
-        -Wall -Wextra -pedantic
-    )
-endif()
 
 include(GoogleTest)
 gtest_discover_tests(Tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 if (MSVC)
-	set(TARGET_COMPILE_OPTIONS
+    set(TARGET_COMPILE_OPTIONS
         /W4
     )
 else()
-	set(TARGET_COMPILE_OPTIONS
+    set(TARGET_COMPILE_OPTIONS
         -Wall -Wextra -pedantic
     )
 endif()
@@ -64,7 +64,6 @@ set(TEST_DIR ${CMAKE_SOURCE_DIR}/test)
 set(TEST_FILES
     ${TEST_DIR}/SimpleTest.cpp
     ${TEST_DIR}/NotSimpleTest.cpp
-    ${TEST_DIR}/Interactive/Audio.cpp
 )
 
 add_executable(Sample
@@ -84,7 +83,7 @@ target_precompile_headers(Sample PRIVATE
     include/pch.hpp
 )
 target_compile_options(Sample PRIVATE
-	${TARGET_COMPILE_OPTIONS}
+    ${TARGET_COMPILE_OPTIONS}
 )
 
 enable_testing()
@@ -106,6 +105,26 @@ target_include_directories(Tests PRIVATE
     ${INCLUDE_DIR}
 )
 target_compile_options(Tests PRIVATE
+    ${TARGET_COMPILE_OPTIONS}
+)
+
+add_executable(AudioTest
+    ${TEST_DIR}/Interactive/Audio.cpp
+    ${SRC_FILES}
+)
+target_link_libraries(AudioTest
+    GTest::gtest_main
+    ${DEPENDENCY_LINK_LIBRARIES}
+)
+target_include_directories(AudioTest SYSTEM PRIVATE
+    ${DEPENDENCY_INCLUDE_DIRS}
+    lib/googletest/googletest/include
+    lib/googletest/googlemock/include
+)
+target_include_directories(AudioTest PRIVATE
+    ${INCLUDE_DIR}
+)
+target_compile_options(AudioTest PRIVATE
     ${TARGET_COMPILE_OPTIONS}
 )
 

--- a/test/Interactive/Audio.cpp
+++ b/test/Interactive/Audio.cpp
@@ -6,6 +6,7 @@
 
 #include "Util/BGM.hpp"
 #include "Util/SFX.hpp"
+#include "Util/Logger.hpp"
 
 bool UserCheck(const std::string &text) {
     while (true) {
@@ -50,8 +51,18 @@ void AudioQuit() {
     Mix_Quit();
 }
 
-TEST(Audio, BGM_TEST) {
-    AudioInit();
+class AudioTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		Util::Logger::Init();
+		AudioInit();
+	}
+	void TearDown() override {
+		AudioQuit();
+	}
+};
+
+TEST_F(AudioTest, BGM_TEST) {
     auto bgm = Util::BGM("../assets/audio/testbgm.mp3");
 
     bgm.Play();
@@ -74,12 +85,9 @@ TEST(Audio, BGM_TEST) {
 
     bgm.FadeOut(1000);
     EXCEPT_INPUT_YES("Is it fading out?");
-
-    AudioQuit();
 }
 
-TEST(Audio, SFX_TEST) {
-    AudioInit();
+TEST_F(AudioTest, SFX_TEST) {
     auto sfx = Util::SFX("../assets/audio/Click.wav");
 
     sfx.Play();
@@ -92,12 +100,9 @@ TEST(Audio, SFX_TEST) {
     sfx.SetVolume(100);
     sfx.Play();
     EXCEPT_INPUT_YES("Is the volume louder than last time?");
-
-    AudioQuit();
 }
 
-TEST(Audio, BGM_SFX_TEST) {
-    AudioInit();
+TEST_F(AudioTest, BGM_SFX_TEST) {
     auto bgm = Util::BGM("../assets/audio/testbgm.mp3");
     auto sfx = Util::SFX("../assets/audio/Click.wav");
 
@@ -133,6 +138,5 @@ TEST(Audio, BGM_SFX_TEST) {
 
     sfx.Play();
     EXCEPT_INPUT_YES("Do you hear the sfx?");
-
-    AudioQuit();
 }
+


### PR DESCRIPTION
### `AudioTest`
- [x] Use a fixture
- [x] Fix missing `Logger::Init`
### `CMakeLists.txt`
- [x] Add `TARGET_COMPILE_OPTIONS`
- [x] Separate `AudioTest` from `Tests`