### PR TITLE
added GLEW_NO_GLU definition

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -91,6 +91,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(sdl2 sdl2_image sdl2_ttf sdl2_mixer spdlog glm googletest)
 
+add_compile_definitions(GLEW_NO_GLU)
+
 FetchContent_GetProperties(glew)
 if (NOT ${glew_POPULATED})
     FetchContent_Populate(glew)


### PR DESCRIPTION
on freshly installed Linux environment project fails to build due this [issue](https://github.com/nigels-com/glew/issues/192), this PR fixes it