### PR TITLE
Able to change image and text

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SRC_FILES
     ${SRC_DIR}/Core/Shader.cpp
     ${SRC_DIR}/Core/Program.cpp
     ${SRC_DIR}/Core/Texture.cpp
+    ${SRC_DIR}/Core/TextureUtils.cpp
 
     ${SRC_DIR}/Util/LoadTextFile.cpp
     ${SRC_DIR}/Util/Logger.cpp
@@ -60,6 +61,7 @@ set(INCLUDE_FILES
     ${INCLUDE_DIR}/Core/Shader.hpp
     ${INCLUDE_DIR}/Core/Program.hpp
     ${INCLUDE_DIR}/Core/Texture.hpp
+    ${INCLUDE_DIR}/Core/TextureUtils.hpp
     ${INCLUDE_DIR}/Core/Drawable.hpp
 
     ${INCLUDE_DIR}/Util/LoadTextFile.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC_FILES
 
     ${SRC_DIR}/App.cpp
     ${SRC_DIR}/Giraffe.cpp
+    ${SRC_DIR}/GiraffeText.cpp
 )
 set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 set(INCLUDE_FILES
@@ -74,9 +75,11 @@ set(INCLUDE_FILES
     ${INCLUDE_DIR}/Util/TransformUtils.hpp
     ${INCLUDE_DIR}/Util/GameObject.hpp
     ${INCLUDE_DIR}/Util/Root.hpp
+    ${INCLUDE_DIR}/Util/Color.hpp
 
     ${INCLUDE_DIR}/App.hpp
     ${INCLUDE_DIR}/Giraffe.hpp
+    ${INCLUDE_DIR}/GiraffeText.hpp
     ${INCLUDE_DIR}/config.hpp
 )
 set(TEST_DIR ${CMAKE_SOURCE_DIR}/test)

--- a/include/Core/Texture.hpp
+++ b/include/Core/Texture.hpp
@@ -6,7 +6,7 @@
 namespace Core {
 class Texture {
 public:
-    Texture(unsigned int channels, int width, int height, const void *data);
+    Texture(GLint format, int width, int height, const void *data);
     Texture(const Texture &) = delete;
     Texture(Texture &&texture);
 
@@ -20,8 +20,7 @@ public:
     void Bind(int slot) const;
     void Unbind() const;
 
-    void UpdateData(unsigned int channels, int width, int height,
-                    const void *data);
+    void UpdateData(GLint format, int width, int height, const void *data);
 
 private:
     GLuint m_TextureId;

--- a/include/Core/TextureUtils.hpp
+++ b/include/Core/TextureUtils.hpp
@@ -1,0 +1,14 @@
+#ifndef CORE_TEXTURE_UTILS_HPP
+#define CORE_TEXTURE_UTILS_HPP
+
+#include "pch.hpp"
+
+#include "Util/Logger.hpp"
+
+namespace Core {
+GLint SdlFormatToGlFormat(Uint32 format);
+
+GLint GlFormatToGlInternalFormat(GLint format);
+} // namespace Core
+
+#endif

--- a/include/Giraffe.hpp
+++ b/include/Giraffe.hpp
@@ -4,27 +4,7 @@
 #include <utility>
 
 #include "Util/GameObject.hpp"
-
-class GiraffeText : public Util::GameObject {
-public:
-    GiraffeText() = default;
-
-    GiraffeText(std::string font, const int size, std::string text)
-        : m_Font(std::move(font)),
-          m_Size(size),
-          m_Text(std::move(text)) {}
-
-    ~GiraffeText() override = default;
-
-    void Start() override;
-
-    void Update(const Util::Transform &transform = Util::Transform()) override;
-
-private:
-    std::string m_Font;
-    int m_Size;
-    std::string m_Text;
-};
+#include "Util/Text.hpp"
 
 class Giraffe : public Util::GameObject {
 

--- a/include/GiraffeText.hpp
+++ b/include/GiraffeText.hpp
@@ -1,0 +1,27 @@
+#ifndef GIRAFFE_TEXT_HPP
+#define GIRAFFE_TEXT_HPP
+
+#include "Util/GameObject.hpp"
+#include "Util/Text.hpp"
+
+class GiraffeText : public Util::GameObject {
+public:
+    GiraffeText() = default;
+
+    GiraffeText(std::string font, const int size)
+        : m_Font(std::move(font)),
+          m_Size(size) {}
+
+    ~GiraffeText() override = default;
+
+    void Start() override;
+
+    void Update(const Util::Transform &transform = Util::Transform()) override;
+
+private:
+    std::string m_Font;
+    int m_Size;
+    std::shared_ptr<Util::Text> m_Text;
+};
+
+#endif

--- a/include/Util/Color.hpp
+++ b/include/Util/Color.hpp
@@ -3,8 +3,6 @@
 
 #include "pch.hpp" // IWYU pragma: export
 
-#include <SDL_pixels.h>
-
 namespace Util {
 class Color : public glm::vec4 {
 public:

--- a/include/Util/Color.hpp
+++ b/include/Util/Color.hpp
@@ -1,0 +1,37 @@
+#ifndef UTIL_COLOR_HPP
+#define UTIL_COLOR_HPP
+
+#include "pch.hpp" // IWYU pragma: export
+
+#include <SDL2/SDL_pixels.h>
+
+namespace Util {
+class Color : public glm::vec4 {
+public:
+    using glm::vec4::vec;
+
+    Color(const glm::vec4 &vec)
+        : glm::vec4(vec) {}
+    Color(glm::vec4 &&vec)
+        : glm::vec4(std::move(vec)) {}
+
+    Color(const SDL_Color &color)
+        : glm::vec4({
+              static_cast<float>(color.r) / 255.0F,
+              static_cast<float>(color.g) / 255.0F,
+              static_cast<float>(color.b) / 255.0F,
+              static_cast<float>(color.a) / 255.0F,
+          }) {}
+
+    SDL_Color ToSdlColor() const {
+        return SDL_Color{
+            static_cast<Uint8>(r * 255),
+            static_cast<Uint8>(g * 255),
+            static_cast<Uint8>(b * 255),
+            static_cast<Uint8>(a * 255),
+        };
+    }
+};
+} // namespace Util
+
+#endif

--- a/include/Util/Color.hpp
+++ b/include/Util/Color.hpp
@@ -3,7 +3,7 @@
 
 #include "pch.hpp" // IWYU pragma: export
 
-#include <SDL2/SDL_pixels.h>
+#include <SDL_pixels.h>
 
 namespace Util {
 class Color : public glm::vec4 {

--- a/include/Util/GameObject.hpp
+++ b/include/Util/GameObject.hpp
@@ -41,7 +41,7 @@ public:
     }
 
     void SetZIndex(float index) { m_ZIndex = index; }
-    void SetDrawable(std::unique_ptr<Core::Drawable> drawable) {
+    void SetDrawable(std::shared_ptr<Core::Drawable> drawable) {
         m_Drawable = std::move(drawable);
     }
 
@@ -61,7 +61,7 @@ public:
 protected:
     Util::Transform m_Transform; // idk if this should be here.
 
-    std::unique_ptr<Core::Drawable> m_Drawable = nullptr;
+    std::shared_ptr<Core::Drawable> m_Drawable = nullptr;
     std::vector<std::shared_ptr<GameObject>> m_Children;
 
     float m_ZIndex;

--- a/include/Util/GameObject.hpp
+++ b/include/Util/GameObject.hpp
@@ -41,14 +41,14 @@ public:
     }
 
     void SetZIndex(float index) { m_ZIndex = index; }
-    void SetDrawable(std::shared_ptr<Core::Drawable> drawable) {
-        m_Drawable = std::move(drawable);
+    void SetDrawable(const std::shared_ptr<Core::Drawable> &drawable) {
+        m_Drawable = drawable;
     }
 
     void SetVisible(bool visible) { m_Visible = visible; }
 
-    void AddChild(std::shared_ptr<GameObject> child) {
-        m_Children.push_back(std::move(child));
+    void AddChild(const std::shared_ptr<GameObject> &child) {
+        m_Children.push_back(child);
     }
 
     virtual void Start() = 0;

--- a/include/Util/Image.hpp
+++ b/include/Util/Image.hpp
@@ -19,6 +19,8 @@ public:
 
     glm::vec2 GetSize() const override { return m_Size; };
 
+    void SetImage(const std::string &filepath);
+
     void Draw(const Util::Transform &transform, const float zIndex) override;
 
 private:
@@ -34,9 +36,9 @@ private:
 
 private:
     std::unique_ptr<Core::Texture> m_Texture = nullptr;
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> m_Surface =
-        nullptr;
-    glm::vec2 m_Size = {0, 0};
+
+    std::string m_Path;
+    glm::vec2 m_Size;
 };
 } // namespace Util
 

--- a/include/Util/Text.hpp
+++ b/include/Util/Text.hpp
@@ -8,15 +8,26 @@
 #include "Core/Drawable.hpp"
 #include "Core/Texture.hpp"
 
+#include "Util/Color.hpp"
 #include "Util/Logger.hpp"
 #include "Util/Transform.hpp"
 
 namespace Util {
 class Text : public Core::Drawable {
 public:
-    Text(const std::string &font, int size, const std::string &text);
+    Text(const std::string &font, int size, const std::string &text,
+         const Util::Color &color = Color(0.0F, 0.0F, 0.0F, 1.0F));
 
     glm::vec2 GetSize() const override { return m_Size; };
+
+    void SetText(const std::string &text) {
+        m_Text = text;
+        ApplyTexture();
+    }
+    void SetColor(const Util::Color &color) {
+        m_Color = color;
+        ApplyTexture();
+    };
 
     void Draw(const Transform &transform, const float zIndex) override;
 
@@ -24,6 +35,8 @@ private:
     void InitProgram();
     void InitVertexArray();
     void InitUniformBuffer();
+
+    void ApplyTexture();
 
     static constexpr int UNIFORM_SURFACE_LOCATION = 0;
 
@@ -33,11 +46,11 @@ private:
 
 private:
     std::unique_ptr<Core::Texture> m_Texture = nullptr;
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> m_Surface =
-        nullptr;
-
     std::unique_ptr<TTF_Font, std::function<void(TTF_Font *)>> m_Font;
-    glm::vec2 m_Size = {0, 0};
+
+    std::string m_Text;
+    Util::Color m_Color;
+    glm::vec2 m_Size;
 };
 } // namespace Util
 

--- a/include/Util/Text.hpp
+++ b/include/Util/Text.hpp
@@ -16,7 +16,7 @@ namespace Util {
 class Text : public Core::Drawable {
 public:
     Text(const std::string &font, int size, const std::string &text,
-         const Util::Color &color = Color(0.0F, 0.0F, 0.0F, 1.0F));
+         const Util::Color &color = Color(0.5F, 0.5F, 0.5F, 1.0F));
 
     glm::vec2 GetSize() const override { return m_Size; };
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -5,16 +5,17 @@
 #include "Util/Keycode.hpp"
 #include "Util/Logger.hpp"
 
+#include "GiraffeText.hpp"
+
 void App::Start() {
     LOG_TRACE("Start");
 
     m_Giraffe->SetDrawable(
-        std::make_unique<Util::Image>("../assets/sprites/giraffe.png"));
+        std::make_shared<Util::Image>("../assets/sprites/giraffe.png"));
     m_Giraffe->SetZIndex(5);
     m_Giraffe->Start();
 
-    auto gf = std::make_shared<GiraffeText>("../assets/fonts/Inter.ttf", 500,
-                                            "Giraffe");
+    auto gf = std::make_shared<GiraffeText>("../assets/fonts/Inter.ttf", 50);
     gf->SetZIndex(m_Giraffe->GetZIndex() - 1);
     gf->Start();
     m_Giraffe->AddChild(gf);

--- a/src/Core/Texture.cpp
+++ b/src/Core/Texture.cpp
@@ -51,6 +51,8 @@ void Texture::UpdateData(GLint format, int width, int height,
                          const void *data) {
     glBindTexture(GL_TEXTURE_2D, m_TextureId);
 
+    // Reference:
+    // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
     glTexImage2D(GL_TEXTURE_2D, 0, GlFormatToGlInternalFormat(format), width,
                  height, 0, format, GL_UNSIGNED_BYTE, data);
 

--- a/src/Core/Texture.cpp
+++ b/src/Core/Texture.cpp
@@ -1,46 +1,13 @@
 #include "Core/Texture.hpp"
 
+#include "Core/TextureUtils.hpp"
+
 #include "Util/Logger.hpp"
 
-GLint ChannelsToInternalFormat(unsigned int channels) {
-    switch (channels) {
-    case 3:
-        return GL_RGB16;
-    case 4:
-        return GL_RGBA16;
-    default:
-        LOG_ERROR("Format currently unsupported");
-        return -1;
-    }
-};
-
-GLint ChannelsToFormat(unsigned int channels) {
-    // Since the color channel in MacOS is invert, we need to return the channel by the condition.
-    // Solved #57
-    switch (channels) {
-    case 3:
-#ifdef __APPLE__
-        return GL_BGR;
-#else
-        return GL_RGB;
-#endif
-    case 4:
-#ifdef __APPLE__
-        return GL_BGRA;
-#else
-        return GL_RGBA;
-#endif
-    default:
-        LOG_ERROR("Format currently unsupported");
-        return -1;
-    }
-};
-
 namespace Core {
-Texture::Texture(unsigned int channels, int width, int height,
-                 const void *data) {
+Texture::Texture(GLint format, int width, int height, const void *data) {
     glGenTextures(1, &m_TextureId);
-    UpdateData(channels, width, height, data);
+    UpdateData(format, width, height, data);
 }
 
 Texture::Texture(Texture &&texture) {
@@ -80,12 +47,12 @@ void Texture::Unbind() const {
  * OpenGL under the hood, so it doesn't make sense to mark it as `const`
  */
 // NOLINTNEXTLINE(readability-make-member-function-const)
-void Texture::UpdateData(unsigned int channels, int width, int height,
+void Texture::UpdateData(GLint format, int width, int height,
                          const void *data) {
     glBindTexture(GL_TEXTURE_2D, m_TextureId);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, ChannelsToInternalFormat(channels), width,
-                 height, 0, ChannelsToFormat(channels), GL_UNSIGNED_BYTE, data);
+    glTexImage2D(GL_TEXTURE_2D, 0, GlFormatToGlInternalFormat(format), width,
+                 height, 0, format, GL_UNSIGNED_BYTE, data);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/Core/TextureUtils.cpp
+++ b/src/Core/TextureUtils.cpp
@@ -8,11 +8,9 @@ GLint SdlFormatToGlFormat(Uint32 format) {
     case SDL_PIXELFORMAT_BGR24:
         return GL_BGR;
     case SDL_PIXELFORMAT_XRGB8888:
-        return GL_BGRA;
-    case SDL_PIXELFORMAT_XBGR8888:
-        return GL_RGBA;
     case SDL_PIXELFORMAT_ARGB8888:
         return GL_BGRA;
+    case SDL_PIXELFORMAT_XBGR8888:
     case SDL_PIXELFORMAT_ABGR8888:
         return GL_RGBA;
     default:

--- a/src/Core/TextureUtils.cpp
+++ b/src/Core/TextureUtils.cpp
@@ -7,6 +7,10 @@ GLint SdlFormatToGlFormat(Uint32 format) {
         return GL_RGB;
     case SDL_PIXELFORMAT_BGR24:
         return GL_BGR;
+    case SDL_PIXELFORMAT_XRGB8888:
+        return GL_BGRA;
+    case SDL_PIXELFORMAT_XBGR8888:
+        return GL_RGBA;
     case SDL_PIXELFORMAT_ARGB8888:
         return GL_BGRA;
     case SDL_PIXELFORMAT_ABGR8888:

--- a/src/Core/TextureUtils.cpp
+++ b/src/Core/TextureUtils.cpp
@@ -3,16 +3,17 @@
 namespace Core {
 GLint SdlFormatToGlFormat(Uint32 format) {
     switch (format) {
-    case SDL_PIXELFORMAT_RGB888:
-        return GL_BGR;
-    case SDL_PIXELFORMAT_BGR888:
+    case SDL_PIXELFORMAT_RGB24:
         return GL_RGB;
+    case SDL_PIXELFORMAT_BGR24:
+        return GL_BGR;
     case SDL_PIXELFORMAT_ARGB8888:
         return GL_BGRA;
     case SDL_PIXELFORMAT_ABGR8888:
         return GL_RGBA;
     default:
-        LOG_ERROR("Format currently unsupported");
+        LOG_ERROR("Format currently unsupported: {}",
+                  SDL_GetPixelFormatName(format));
         return -1;
     }
 }

--- a/src/Core/TextureUtils.cpp
+++ b/src/Core/TextureUtils.cpp
@@ -1,0 +1,33 @@
+#include "Core/TextureUtils.hpp"
+
+namespace Core {
+GLint SdlFormatToGlFormat(Uint32 format) {
+    switch (format) {
+    case SDL_PIXELFORMAT_RGB888:
+        return GL_BGR;
+    case SDL_PIXELFORMAT_BGR888:
+        return GL_RGB;
+    case SDL_PIXELFORMAT_ARGB8888:
+        return GL_BGRA;
+    case SDL_PIXELFORMAT_ABGR8888:
+        return GL_RGBA;
+    default:
+        LOG_ERROR("Format currently unsupported");
+        return -1;
+    }
+}
+
+GLint GlFormatToGlInternalFormat(GLint format) {
+    switch (format) {
+    case GL_RGB:
+    case GL_BGR:
+        return GL_RGB16;
+    case GL_RGBA:
+    case GL_BGRA:
+        return GL_RGBA16;
+    default:
+        LOG_ERROR("Format currently unsupported");
+        return -1;
+    }
+}
+} // namespace Core

--- a/src/Giraffe.cpp
+++ b/src/Giraffe.cpp
@@ -11,24 +11,6 @@
 
 #include "config.hpp"
 
-void GiraffeText::Update(const Util::Transform &transform) {
-    auto &pos = m_Transform.translation;
-    auto &scale = m_Transform.scale;
-    auto &rotation = m_Transform.rotation;
-
-    pos = transform.translation;
-    // rotation = std::fmod(rotation + 50.0F, 360.0F);
-    scale = transform.scale;
-
-    LOG_DEBUG("{} {}", scale.x, scale.y);
-
-    m_Drawable->Draw(m_Transform, m_ZIndex);
-}
-
-void GiraffeText::Start() {
-    this->SetDrawable(std::make_unique<Util::Text>(m_Font, m_Size, m_Text));
-}
-
 void Giraffe::Start() {}
 
 void Giraffe::Update([[maybe_unused]] const Util::Transform &transform) {
@@ -54,7 +36,7 @@ void Giraffe::Update([[maybe_unused]] const Util::Transform &transform) {
 
     pos += deltaTransform.translation;
     rotation += deltaTransform.rotation;
-    scale = deltaTransform.scale;
+    // scale = deltaTransform.scale;
 
     m_Drawable->Draw(m_Transform, m_ZIndex);
     for (auto &child : m_Children) {

--- a/src/GiraffeText.cpp
+++ b/src/GiraffeText.cpp
@@ -1,0 +1,27 @@
+#include "GiraffeText.hpp"
+
+#include "Util/Color.hpp"
+#include "Util/Time.hpp"
+
+void GiraffeText::Start() {
+    m_Text = std::make_unique<Util::Text>(m_Font, m_Size, "0",
+                                          Util::Color(1, 1, 1, 1));
+    SetDrawable(m_Text);
+}
+
+void GiraffeText::Update(const Util::Transform &transform) {
+    // auto &pos = m_Transform.translation;
+    // auto &scale = m_Transform.scale;
+    // auto &rotation = m_Transform.rotation;
+
+    // pos = transform.translation;
+    // rotation = std::fmod(rotation + 50.0F, 360.0F);
+    // scale = transform.scale;
+    m_Text->SetText(fmt::format("{:.02f}", 1.0F / Util::Time::GetDeltaTime()));
+
+    m_Text->SetColor({1, 0, 0, 1});
+
+    // LOG_DEBUG("{} {}", scale.x, scale.y);
+
+    m_Drawable->Draw(m_Transform, m_ZIndex);
+}

--- a/src/Util/Image.cpp
+++ b/src/Util/Image.cpp
@@ -1,8 +1,10 @@
-#include "Core/Texture.hpp"
+#include "Util/Image.hpp"
 
 #include "pch.hpp"
 
-#include "Util/Image.hpp"
+#include "Core/Texture.hpp"
+#include "Core/TextureUtils.hpp"
+
 #include "Util/TransformUtils.hpp"
 
 #include "config.hpp"
@@ -27,8 +29,8 @@ Image::Image(const std::string &filepath) {
     }
 
     m_Texture = std::make_unique<Core::Texture>(
-        m_Surface->format->BytesPerPixel, m_Surface->w, m_Surface->h,
-        m_Surface->pixels);
+        Core::SdlFormatToGlFormat(m_Surface->format->format), m_Surface->w,
+        m_Surface->h, m_Surface->pixels);
     m_Size = {m_Surface->w, m_Surface->h};
 }
 

--- a/src/Util/Image.cpp
+++ b/src/Util/Image.cpp
@@ -22,8 +22,11 @@ Image::Image(const std::string &filepath)
         InitUniformBuffer();
     }
 
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> surface = {
-        IMG_Load(filepath.c_str()), SDL_FreeSurface};
+    auto surface =
+        std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>>{
+            IMG_Load(filepath.c_str()),
+            SDL_FreeSurface,
+        };
     if (surface == nullptr) {
         LOG_ERROR("Failed to load image: '{}'", filepath);
         LOG_ERROR("{}", IMG_GetError());
@@ -36,8 +39,11 @@ Image::Image(const std::string &filepath)
 }
 
 void Image::SetImage(const std::string &filepath) {
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> surface = {
-        IMG_Load(filepath.c_str()), SDL_FreeSurface};
+    auto surface =
+        std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>>{
+            IMG_Load(filepath.c_str()),
+            SDL_FreeSurface,
+        };
     if (surface == nullptr) {
         LOG_ERROR("Failed to load image: '{}'", filepath);
         LOG_ERROR("{}", IMG_GetError());

--- a/src/Util/Text.cpp
+++ b/src/Util/Text.cpp
@@ -8,7 +8,10 @@
 #include "config.hpp"
 
 namespace Util {
-Text::Text(const std::string &font, int size, const std::string &text) {
+Text::Text(const std::string &font, int fontSize, const std::string &text,
+           const Util::Color &color)
+    : m_Text(text),
+      m_Color(color) {
     if (s_Program == nullptr) {
         InitProgram();
     }
@@ -19,28 +22,14 @@ Text::Text(const std::string &font, int size, const std::string &text) {
         InitUniformBuffer();
     }
 
-    m_Font = {TTF_OpenFont(font.c_str(), size), TTF_CloseFont};
+    m_Font = {TTF_OpenFont(font.c_str(), fontSize), TTF_CloseFont};
 
     if (m_Font == nullptr) {
         LOG_ERROR("Failed to load font: '{}'", text);
         LOG_ERROR("{}", TTF_GetError());
     }
 
-    m_Surface = {TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), text.c_str(),
-                                                SDL_Color{255, 0, 255, 0}, 0),
-                 SDL_FreeSurface};
-
-    if (m_Surface == nullptr) {
-        LOG_ERROR("Failed to create text");
-        LOG_ERROR("{}", TTF_GetError());
-    }
-
-    m_Texture = std::make_unique<Core::Texture>(
-        m_Surface->format->BytesPerPixel,
-        m_Surface->pitch / m_Surface->format->BytesPerPixel, m_Surface->h,
-        m_Surface->pixels);
-    m_Size = {m_Surface->pitch / m_Surface->format->BytesPerPixel,
-              m_Surface->h};
+    ApplyTexture();
 }
 
 void Text::Draw(const Util::Transform &transform, const float zIndex) {
@@ -104,6 +93,27 @@ void Text::InitVertexArray() {
 void Text::InitUniformBuffer() {
     s_UniformBuffer = std::make_unique<Core::UniformBuffer<Core::Matrices>>(
         *s_Program, "Matrices", 0);
+}
+
+void Text::ApplyTexture() {
+    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> surface = {
+        TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), m_Text.c_str(),
+                                       m_Color.ToSdlColor(), 0),
+        SDL_FreeSurface};
+
+    if (surface == nullptr) {
+        LOG_ERROR("Failed to create text");
+        LOG_ERROR("{}", TTF_GetError());
+    }
+
+    LOG_INFO("{}", glm::to_string((glm::vec4)m_Color));
+    LOG_INFO("{}", SDL_GetPixelFormatName(surface->format->format));
+
+    m_Texture = std::make_unique<Core::Texture>(
+        surface->format->BytesPerPixel,
+        surface->pitch / surface->format->BytesPerPixel, surface->h,
+        surface->pixels);
+    m_Size = {surface->pitch / surface->format->BytesPerPixel, surface->h};
 }
 
 std::unique_ptr<Core::Program> Text::s_Program = nullptr;

--- a/src/Util/Text.cpp
+++ b/src/Util/Text.cpp
@@ -30,10 +30,12 @@ Text::Text(const std::string &font, int fontSize, const std::string &text,
         LOG_ERROR("{}", TTF_GetError());
     }
 
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> surface = {
-        TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), m_Text.c_str(),
-                                       m_Color.ToSdlColor(), 0),
-        SDL_FreeSurface};
+    auto surface =
+        std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>>{
+            TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), m_Text.c_str(),
+                                           m_Color.ToSdlColor(), 0),
+            SDL_FreeSurface,
+        };
     if (surface == nullptr) {
         LOG_ERROR("Failed to create text");
         LOG_ERROR("{}", TTF_GetError());
@@ -110,10 +112,12 @@ void Text::InitUniformBuffer() {
 }
 
 void Text::ApplyTexture() {
-    std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>> surface = {
-        TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), m_Text.c_str(),
-                                       m_Color.ToSdlColor(), 0),
-        SDL_FreeSurface};
+    auto surface =
+        std::unique_ptr<SDL_Surface, std::function<void(SDL_Surface *)>>{
+            TTF_RenderUTF8_Blended_Wrapped(m_Font.get(), m_Text.c_str(),
+                                           m_Color.ToSdlColor(), 0),
+            SDL_FreeSurface,
+        };
     if (surface == nullptr) {
         LOG_ERROR("Failed to create text: {}", TTF_GetError());
     }


### PR DESCRIPTION
Changelog:
- Added `Image::SetImage()`
- Added `Text::SetText()` and `Text::SetColor()`
- Fixed bug where color channels are inverted(i.e. blue text shows up red)
- Change `GameObject.m_Drawable` to `shared_ptr` make it changeable

Note:
Currently loading the same image still isn't cached

Related Issues:
- Fix #93 
- Fix #97 
- #64