### PR TITLE
Update game object and adapt Util::Root

### DIFF
--- a/include/App.hpp
+++ b/include/App.hpp
@@ -4,6 +4,8 @@
 #include "pch.hpp" // IWYU pragma: export
 
 #include "Giraffe.hpp"
+#include "GiraffeText.hpp"
+#include "Util/Root.hpp"
 
 class App {
 public:
@@ -23,6 +25,9 @@ private:
     State m_CurrentState = State::START;
 
     std::shared_ptr<Giraffe> m_Giraffe = std::make_shared<Giraffe>();
+    //    std::shared_ptr<GiraffeText> m_GiraffeText =
+    //    std::make_shared<GiraffeText>();
+    Util::Root m_Root;
 };
 
 #endif

--- a/include/Giraffe.hpp
+++ b/include/Giraffe.hpp
@@ -3,15 +3,19 @@
 
 #include <utility>
 
+#include "GiraffeText.hpp"
 #include "Util/GameObject.hpp"
 #include "Util/Text.hpp"
 
 class Giraffe : public Util::GameObject {
 
 public:
-    void Update(const Util::Transform &transform = Util::Transform()) override;
+    void Update();
 
-    void Start() override;
+    void Start();
+
+private:
+    std::shared_ptr<GiraffeText> m_GiraffeText;
 };
 
 #endif

--- a/include/GiraffeText.hpp
+++ b/include/GiraffeText.hpp
@@ -14,9 +14,9 @@ public:
 
     ~GiraffeText() override = default;
 
-    void Start() override;
+    void Start();
 
-    void Update(const Util::Transform &transform = Util::Transform()) override;
+    void Update();
 
 private:
     std::string m_Font;

--- a/include/Util/GameObject.hpp
+++ b/include/Util/GameObject.hpp
@@ -121,6 +121,16 @@ public:
         m_Children.push_back(child);
     }
 
+    /**
+     * @brief Remove a child from the game object.
+     *
+     * @param child The child to be removed.
+     */
+    void RemoveChild(const std::shared_ptr<GameObject> &child) {
+        m_Children.erase(std::remove(m_Children.begin(), m_Children.end(), child),
+                         m_Children.end());
+    }
+
     void Draw();
 
 protected:

--- a/include/Util/GameObject.hpp
+++ b/include/Util/GameObject.hpp
@@ -121,25 +121,6 @@ public:
         m_Children.push_back(child);
     }
 
-    /**
-     * @brief Start the game object.
-     *
-     * This is a pure virtual function that needs to be implemented by derived
-     * classes.
-     */
-    virtual void Start() = 0;
-
-    /**
-     * @brief Update the game object.
-     *
-     * This is a pure virtual function that needs to be implemented by derived
-     * classes.
-     *
-     * @param transform The new transform of the game object.
-     */
-    virtual void
-    Update(const Util::Transform &transform = Util::Transform()) = 0;
-
     void Draw();
 
 protected:

--- a/include/Util/Root.hpp
+++ b/include/Util/Root.hpp
@@ -24,7 +24,7 @@ public:
      *
      * @param child The GameObject needing to be managed by the root.
      */
-    void AddChild(std::shared_ptr<GameObject> child);
+    void AddChild(const std::shared_ptr<GameObject> &child);
 
     /**
      * @brief Add children to the root.
@@ -32,6 +32,13 @@ public:
      * @param children The GameObjects needing to be managed by the root.
      */
     void AddChildren(const std::vector<std::shared_ptr<GameObject>> &children);
+
+    /**
+     * @brief Remove the child.
+     *
+     * @param child The GameObject being removed.
+     */
+    void RemoveChild(std::shared_ptr<GameObject> child);
 
     /**
      * @brief Draw children according to their z-index.

--- a/include/Util/Root.hpp
+++ b/include/Util/Root.hpp
@@ -13,7 +13,7 @@ class Root final {
 public:
     /**
      * @brief Parameterized constructor.
-     *` 
+     *`
      *
      * @param children The GameObject needing to be managed by the root.
      */

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -15,10 +15,7 @@ void App::Start() {
     m_Giraffe->SetZIndex(5);
     m_Giraffe->Start();
 
-    auto gf = std::make_shared<GiraffeText>("../assets/fonts/Inter.ttf", 50);
-    gf->SetZIndex(m_Giraffe->GetZIndex() - 1);
-    gf->Start();
-    m_Giraffe->AddChild(gf);
+    m_Root.AddChild(m_Giraffe);
 
     m_CurrentState = State::UPDATE;
 }
@@ -55,6 +52,8 @@ void App::Update() {
     }
 
     m_Giraffe->Update();
+
+    m_Root.Update();
 }
 
 void App::End() { // NOLINT(this method will mutate members in the future)

--- a/src/Core/DebugMessageCallback.cpp
+++ b/src/Core/DebugMessageCallback.cpp
@@ -74,7 +74,7 @@ void GLAPIENTRY OpenGLDebugMessageCallback(GLenum source, GLenum type,
         LOG_DEBUG(" Type: {}", typeString);
         LOG_DEBUG(" Message: {}", message);
         break;
-        
+
     default:
         LOG_DEBUG("OpenGL Severity Unknown");
         LOG_DEBUG(" ID: {}", id);

--- a/src/Giraffe.cpp
+++ b/src/Giraffe.cpp
@@ -2,18 +2,20 @@
 
 #include <cmath>
 
-#include "Util/GameObject.hpp"
-#include "Util/Image.hpp"
-#include "Util/Logger.hpp"
-#include "Util/Text.hpp"
 #include "Util/Time.hpp"
 #include "Util/Transform.hpp"
 
 #include "config.hpp"
 
-void Giraffe::Start() {}
+void Giraffe::Start() {
+    m_GiraffeText =
+        std::make_shared<GiraffeText>("../assets/fonts/Inter.ttf", 50);
+    m_GiraffeText->SetZIndex(this->GetZIndex() - 1);
+    m_GiraffeText->Start();
+    this->AddChild(m_GiraffeText);
+}
 
-void Giraffe::Update([[maybe_unused]] const Util::Transform &transform) {
+void Giraffe::Update() {
     static glm::vec2 dir = {1, 0.5};
 
     auto &pos = m_Transform.translation;
@@ -36,12 +38,6 @@ void Giraffe::Update([[maybe_unused]] const Util::Transform &transform) {
 
     pos += deltaTransform.translation;
     rotation += deltaTransform.rotation;
-    // scale = deltaTransform.scale;
 
-    m_Drawable->Draw(m_Transform, m_ZIndex);
-    for (auto &child : m_Children) {
-        child->Update(m_Transform);
-    }
-
-    // LOG_DEBUG("GIRA: x: {}, y: {}", pos.x, pos.y);
+    m_GiraffeText->Update();
 }

--- a/src/GiraffeText.cpp
+++ b/src/GiraffeText.cpp
@@ -13,6 +13,4 @@ void GiraffeText::Update() {
     m_Text->SetText(fmt::format("{:.02f}", 1.0F / Util::Time::GetDeltaTime()));
 
     m_Text->SetColor({1, 0, 0, 1});
-
-    m_Drawable->Draw(m_Transform, m_ZIndex);
 }

--- a/src/GiraffeText.cpp
+++ b/src/GiraffeText.cpp
@@ -9,19 +9,10 @@ void GiraffeText::Start() {
     SetDrawable(m_Text);
 }
 
-void GiraffeText::Update(const Util::Transform &transform) {
-    // auto &pos = m_Transform.translation;
-    // auto &scale = m_Transform.scale;
-    // auto &rotation = m_Transform.rotation;
-
-    // pos = transform.translation;
-    // rotation = std::fmod(rotation + 50.0F, 360.0F);
-    // scale = transform.scale;
+void GiraffeText::Update() {
     m_Text->SetText(fmt::format("{:.02f}", 1.0F / Util::Time::GetDeltaTime()));
 
     m_Text->SetColor({1, 0, 0, 1});
-
-    // LOG_DEBUG("{} {}", scale.x, scale.y);
 
     m_Drawable->Draw(m_Transform, m_ZIndex);
 }

--- a/src/Util/Input.cpp
+++ b/src/Util/Input.cpp
@@ -54,7 +54,8 @@ void Input::Update() {
     s_CursorPosition.y = static_cast<float>(y);
 
     s_CursorPosition.x -= static_cast<float>(WINDOW_WIDTH) / 2;
-    s_CursorPosition.y = -(s_CursorPosition.y - static_cast<float>(WINDOW_HEIGHT) / 2);
+    s_CursorPosition.y =
+        -(s_CursorPosition.y - static_cast<float>(WINDOW_HEIGHT) / 2);
 
     s_LBPressed = s_RBPressed = s_MBPressed = s_Scroll = s_MouseMoving = false;
 

--- a/src/Util/Root.cpp
+++ b/src/Util/Root.cpp
@@ -6,8 +6,13 @@ namespace Util {
 Root::Root(const std::vector<std::shared_ptr<GameObject>> &children)
     : m_Children(children) {}
 
-void Root::AddChild(std::shared_ptr<GameObject> child) {
+void Root::AddChild(const std::shared_ptr<GameObject>& child) {
     m_Children.push_back(child);
+}
+
+void Root::RemoveChild(std::shared_ptr<GameObject> child) {
+    m_Children.erase(std::remove(m_Children.begin(), m_Children.end(), child),
+                     m_Children.end());
 }
 
 void Root::AddChildren(

--- a/src/Util/Root.cpp
+++ b/src/Util/Root.cpp
@@ -33,7 +33,6 @@ void Root::Update() {
         auto curr = stack.back();
         stack.pop_back();
 
-        curr.m_GameObject->Update(curr.m_ParentTransform);
         curr.m_GameObject->Draw();
 
         for (const auto &child : curr.m_GameObject->GetChildren()) {

--- a/src/Util/Time.cpp
+++ b/src/Util/Time.cpp
@@ -12,6 +12,7 @@ void Util::Time::Update() {
                   static_cast<double>(SDL_GetPerformanceFrequency());
 }
 
-unsigned long Util::Time::s_Now = static_cast<unsigned long>(SDL_GetPerformanceCounter());
+unsigned long Util::Time::s_Now =
+    static_cast<unsigned long>(SDL_GetPerformanceCounter());
 unsigned long Util::Time::s_Last = 0;
 double Util::Time::s_DeltaTime = 0;


### PR DESCRIPTION
#87  but also adapts #84 to Sample's GameObject render.

## Changelog
- Remove `Start()` and `Update()` from `Util::GameObject`.
- Add `RemoveChild(shared_ptr<Util::GameObject>)` to both `Util::GameObject` and `Util::Root`.
- Adapt `Util::Root`-way to render GameObjects in `Sample`.
- Refactor some mess found.