### PR TITLE
Implement `Util::Color` APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ target_include_directories(Sample PRIVATE
 if (${PTSD_ENABLE_PCH})
     target_precompile_headers(Sample PRIVATE
         include/pch.hpp
-    )
+)
 endif()
 target_compile_options(Sample PRIVATE
     ${TARGET_COMPILE_OPTIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SRC_FILES
     ${SRC_DIR}/Util/TransformUtils.cpp
     ${SRC_DIR}/Util/GameObject.cpp
     ${SRC_DIR}/Util/Root.cpp
+    ${SRC_DIR}/Util/Color.cpp
 
     ${SRC_DIR}/App.cpp
     ${SRC_DIR}/Giraffe.cpp
@@ -119,7 +120,7 @@ enable_testing()
 add_executable(Tests
     ${TEST_FILES}
     ${SRC_FILES}
-)
+ )
 target_link_libraries(Tests
     GTest::gtest_main
     ${DEPENDENCY_LINK_LIBRARIES}

--- a/include/Util/Color.hpp
+++ b/include/Util/Color.hpp
@@ -25,6 +25,17 @@ public:
 
     /*
      * @brief Parameterized constructor.
+     *
+     * @param r The red component of the color.
+     * @param g The green component of the color.
+     * @param b The blue component of the color.
+     * @param a The alpha component of the color.
+     */
+    Color(Uint8 r, Uint8 g, Uint8 b, Uint8 a = 255)
+        : glm::vec4(r, g, b, a) {}
+
+    /*
+     * @brief Parameterized constructor.
      */
     Color(glm::vec4 &&vec)
         : glm::vec4(std::move(vec)) {}
@@ -36,10 +47,10 @@ public:
      */
     Color(const SDL_Color &color)
         : glm::vec4({
-              static_cast<float>(color.r) / 255.0F,
-              static_cast<float>(color.g) / 255.0F,
-              static_cast<float>(color.b) / 255.0F,
-              static_cast<float>(color.a) / 255.0F,
+              color.r,
+              color.g,
+              color.b,
+              color.a,
           }) {}
 
     /**
@@ -49,12 +60,67 @@ public:
      */
     SDL_Color ToSdlColor() const {
         return SDL_Color{
-            static_cast<Uint8>(r * 255),
-            static_cast<Uint8>(g * 255),
-            static_cast<Uint8>(b * 255),
-            static_cast<Uint8>(a * 255),
+            static_cast<Uint8>(r),
+            static_cast<Uint8>(g),
+            static_cast<Uint8>(b),
+            static_cast<Uint8>(a),
         };
     }
+
+    /**
+     * @brief Get Color From RGB Values
+     * @param r Red Value (0-255)
+     * @param g Green Value (0-255)
+     * @param b Blue Value (0-255)
+     * @param a Alpha Value (0-255), default is 255
+     * @return Color
+     */
+    static Color FromRGB(Uint8 r, Uint8 g, Uint8 b, Uint8 a = 255);
+
+    /**
+     * @brief Get Color From HSL Values
+     * @param h Hue Value (0-360)
+     * @param s Saturation Value (0-1)
+     * @param l Lightness Value (0-1)
+     * @param a Alpha Value (0-1), default is 1.0
+     * @return Color
+     */
+    static Color FromHSL(float h, float s, float l, float a = 1.0F);
+
+    /**
+     * @brief Get Color From HSV Values
+     * @param h Hue Value (0-360)
+     * @param s Saturation Value (0-1)
+     * @param v Value (0-1)
+     * @param a Alpha Value (0-1), default is 1.0
+     * @return Color
+     */
+    static Color FromHSV(float h, float s, float v, float a = 1.0F);
+
+    /**
+     * @brief Get Color From Hex RGB Value, alpha value is necessary
+     * @param hex Hex Value (0x00000000 - 0xFFFFFFFF)
+     * @return Color
+     */
+    static Color FromHex(Uint32 hex);
+
+    /**
+     * @brief Get Color From Hex RGB String
+     * @param hex Hex String ("00000000" - "FFFFFFFF")
+     * @return Color
+     */
+    static Color FromHex(const std::string &hex);
+
+    /**
+     * @brief Get Color From Name
+     * @param name Color Name, case insensitive, see Util/Color.cpp for
+     * available names
+     * @return Color
+     */
+    static Color FromName(const std::string &name);
+
+private:
+    static std::unordered_map<std::string, Uint32> s_ColorNames;
 };
 } // namespace Util
 

--- a/include/Util/Text.hpp
+++ b/include/Util/Text.hpp
@@ -24,7 +24,7 @@ namespace Util {
 class Text : public Core::Drawable {
 public:
     Text(const std::string &font, int size, const std::string &text,
-         const Util::Color &color = Color(0.5F, 0.5F, 0.5F, 1.0F));
+         const Util::Color &color = Color(127, 127, 127));
 
     glm::vec2 GetSize() const override { return m_Size; };
 

--- a/include/pch.hpp
+++ b/include/pch.hpp
@@ -1,11 +1,15 @@
 #ifndef PCH_HPP
 #define PCH_HPP
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <set>
+#include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
 
 #include <SDL.h>
 #include <SDL_events.h>

--- a/src/GiraffeText.cpp
+++ b/src/GiraffeText.cpp
@@ -5,12 +5,12 @@
 
 void GiraffeText::Start() {
     m_Text = std::make_unique<Util::Text>(m_Font, m_Size, "0",
-                                          Util::Color(1, 1, 1, 1));
+                                          Util::Color(255, 255, 255));
     SetDrawable(m_Text);
 }
 
 void GiraffeText::Update() {
     m_Text->SetText(fmt::format("{:.02f}", 1.0F / Util::Time::GetDeltaTime()));
 
-    m_Text->SetColor({1, 0, 0, 1});
+    m_Text->SetColor(Util::Color::FromName("Red"));
 }

--- a/src/Util/Color.cpp
+++ b/src/Util/Color.cpp
@@ -1,0 +1,222 @@
+#include "Util/Color.hpp"
+#include "Util/Logger.hpp"
+namespace Util {
+
+Color Color::FromRGB(Uint8 r, Uint8 g, Uint8 b, Uint8 a) {
+    if (r > 255 || g > 255 || b > 255 || a > 255) {
+        LOG_ERROR("Invalid color: ({}, {}, {}, {})", r, g, b, a);
+        throw std::invalid_argument("Invalid color");
+    }
+    return Color(r, g, b, a);
+}
+
+Color Color::FromHex(Uint32 hex) {
+    return Color((hex >> 24) & 0xFF, (hex >> 16) & 0xFF, (hex >> 8) & 0xFF,
+                 hex & 0xFF);
+}
+
+Color Color::FromHex(const std::string &hex) {
+    try {
+        Uint32 hexValue = std::stoul(hex, nullptr, 16);
+        return FromHex(hexValue);
+    } catch (const std::invalid_argument &e) {
+        LOG_ERROR("Invalid color hex: '{}'", hex);
+        throw std::invalid_argument("Invalid hex string");
+    }
+}
+
+Color Color::FromName(const std::string &name) {
+    try {
+        std::string colorName = name;
+        std::transform(colorName.begin(), colorName.end(), colorName.begin(),
+                       ::tolower);
+        Uint32 hexValue = s_ColorNames.at(colorName) << 8 | 0xFF;
+        return FromHex(hexValue);
+    } catch (const std::out_of_range &e) {
+        LOG_ERROR("Invalid color name: '{}'", name);
+        throw std::invalid_argument("Invalid color name");
+    }
+}
+
+Color Color::FromHSL(float h, float s, float l, float a) {
+
+    float chroma = (1 - std::abs(2 * l - 1)) * s;
+    float huePrime = h * 6;
+    float x = chroma * (1 - std::abs(std::fmod(huePrime, 2) - 1));
+    float m = l - chroma / 2;
+
+    std::array<float, 3> rgb1 = {0, 0, 0};
+    int hueSegment = static_cast<int>(huePrime);
+    rgb1[hueSegment % 3] = chroma;
+    rgb1[(hueSegment + 1) % 3] = x;
+
+    Uint8 r = static_cast<Uint8>((rgb1[0] + m) * 255);
+    Uint8 g = static_cast<Uint8>((rgb1[1] + m) * 255);
+    Uint8 b = static_cast<Uint8>((rgb1[2] + m) * 255);
+
+    return Color(r, g, b, a);
+}
+
+Color Color::FromHSV(float h, float s, float v, float a) {
+    float chroma = v * s;
+    float huePrime = h * 6;
+    float x = chroma * (1 - std::abs(std::fmod(huePrime, 2) - 1));
+    float m = v - chroma;
+
+    std::array<float, 3> rgb1 = {0, 0, 0};
+    int hueSegment = static_cast<int>(huePrime);
+    rgb1[hueSegment % 3] = chroma;
+    rgb1[(hueSegment + 1) % 3] = x;
+
+    Uint8 r = static_cast<Uint8>((rgb1[0] + m) * 255);
+    Uint8 g = static_cast<Uint8>((rgb1[1] + m) * 255);
+    Uint8 b = static_cast<Uint8>((rgb1[2] + m) * 255);
+
+    return Color(r, g, b, a);
+}
+
+std::unordered_map<std::string, Uint32> Color::s_ColorNames = {
+    {"aliceblue", 0xF0F8FF},
+    {"antiquewhite", 0xFAEBD7},
+    {"aqua", 0x00FFFF},
+    {"aquamarine", 0x7FFFD4},
+    {"azure", 0xF0FFFF},
+    {"beige", 0xF5F5DC},
+    {"bisque", 0xFFE4C4},
+    {"black", 0x000000},
+    {"blanchedalmond", 0xFFEBCD},
+    {"blue", 0x0000FF},
+    {"blueviolet", 0x8A2BE2},
+    {"brown", 0xA52A2A},
+    {"burlywood", 0xDEB887},
+    {"cadetblue", 0x5F9EA0},
+    {"chartreuse", 0x7FFF00},
+    {"chocolate", 0xD2691E},
+    {"coral", 0xFF7F50},
+    {"cornflowerblue", 0x6495ED},
+    {"cornsilk", 0xFFF8DC},
+    {"crimson", 0xDC143C},
+    {"cyan", 0x00FFFF},
+    {"darkblue", 0x00008B},
+    {"darkcyan", 0x008B8B},
+    {"darkgoldenrod", 0xB8860B},
+    {"darkgray", 0xA9A9A9},
+    {"darkgreen", 0x006400},
+    {"darkkhaki", 0xBDB76B},
+    {"darkmagenta", 0x8B008B},
+    {"darkolivegreen", 0x556B2F},
+    {"darkorange", 0xFF8C00},
+    {"darkorchid", 0x9932CC},
+    {"darkred", 0x8B0000},
+    {"darksalmon", 0xE9967A},
+    {"darkseagreen", 0x8FBC8F},
+    {"darkslateblue", 0x483D8B},
+    {"darkslategray", 0x2F4F4F},
+    {"darkturquoise", 0x00CED1},
+    {"darkviolet", 0x9400D3},
+    {"deeppink", 0xFF1493},
+    {"deepskyblue", 0x00BFFF},
+    {"dimgray", 0x696969},
+    {"dodgerblue", 0x1E90FF},
+    {"firebrick", 0xB22222},
+    {"floralwhite", 0xFFFAF0},
+    {"forestgreen", 0x228B22},
+    {"fuchsia", 0xFF00FF},
+    {"gainsboro", 0xDCDCDC},
+    {"ghostwhite", 0xF8F8FF},
+    {"gold", 0xFFD700},
+    {"goldenrod", 0xDAA520},
+    {"gray", 0x808080},
+    {"green", 0x008000},
+    {"greenyellow", 0xADFF2F},
+    {"honeydew", 0xF0FFF0},
+    {"hotpink", 0xFF69B4},
+    {"indianred", 0xCD5C5C},
+    {"indigo", 0x4B0082},
+    {"ivory", 0xFFFFF0},
+    {"khaki", 0xF0E68C},
+    {"lavender", 0xE6E6FA},
+    {"lavenderblush", 0xFFF0F5},
+    {"lawngreen", 0x7CFC00},
+    {"lemonchiffon", 0xFFFACD},
+    {"lightblue", 0xADD8E6},
+    {"lightcoral", 0xF08080},
+    {"lightcyan", 0xE0FFFF},
+    {"lightgoldenrodyellow", 0xFAFAD2},
+    {"lightgray", 0xD3D3D3},
+    {"lightgreen", 0x90EE90},
+    {"lightpink", 0xFFB6C1},
+    {"lightsalmon", 0xFFA07A},
+    {"lightseagreen", 0x20B2AA},
+    {"lightskyblue", 0x87CEFA},
+    {"lightslategray", 0x778899},
+    {"lightsteelblue", 0xB0C4DE},
+    {"lightyellow", 0xFFFFE0},
+    {"lime", 0x00FF00},
+    {"limegreen", 0x32CD32},
+    {"linen", 0xFAF0E6},
+    {"magenta", 0xFF00FF},
+    {"maroon", 0x800000},
+    {"mediumaquamarine", 0x66CDAA},
+    {"mediumblue", 0x0000CD},
+    {"mediumorchid", 0xBA55D3},
+    {"mediumpurple", 0x9370DB},
+    {"mediumseagreen", 0x3CB371},
+    {"mediumslateblue", 0x7B68EE},
+    {"mediumspringgreen", 0x00FA9A},
+    {"mediumturquoise", 0x48D1CC},
+    {"mediumvioletred", 0xC71585},
+    {"midnightblue", 0x191970},
+    {"mintcream", 0xF5FFFA},
+    {"mistyrose", 0xFFE4E1},
+    {"moccasin", 0xFFE4B5},
+    {"navajowhite", 0xFFDEAD},
+    {"navy", 0x000080},
+    {"oldlace", 0xFDF5E6},
+    {"olive", 0x808000},
+    {"olivedrab", 0x6B8E23},
+    {"orange", 0xFFA500},
+    {"orangered", 0xFF4500},
+    {"orchid", 0xDA70D6},
+    {"palegoldenrod", 0xEEE8AA},
+    {"palegreen", 0x98FB98},
+    {"paleturquoise", 0xAFEEEE},
+    {"palevioletred", 0xDB7093},
+    {"papayawhip", 0xFFEFD5},
+    {"peachpuff", 0xFFDAB9},
+    {"peru", 0xCD853F},
+    {"pink", 0xFFC0CB},
+    {"plum", 0xDDA0DD},
+    {"powderblue", 0xB0E0E6},
+    {"purple", 0x800080},
+    {"rebeccapurple", 0x663399},
+    {"red", 0xFF0000},
+    {"rosybrown", 0xBC8F8F},
+    {"royalblue", 0x4169E1},
+    {"saddlebrown", 0x8B4513},
+    {"salmon", 0xFA8072},
+    {"sandybrown", 0xF4A460},
+    {"seagreen", 0x2E8B57},
+    {"seashell", 0xFFF5EE},
+    {"sienna", 0xA0522D},
+    {"silver", 0xC0C0C0},
+    {"skyblue", 0x87CEEB},
+    {"slateblue", 0x6A5ACD},
+    {"slategray", 0x708090},
+    {"snow", 0xFFFAFA},
+    {"springgreen", 0x00FF7F},
+    {"steelblue", 0x4682B4},
+    {"tan", 0xD2B48C},
+    {"teal", 0x008080},
+    {"thistle", 0xD8BFD8},
+    {"tomato", 0xFF6347},
+    {"turquoise", 0x40E0D0},
+    {"violet", 0xEE82EE},
+    {"wheat", 0xF5DEB3},
+    {"white", 0xFFFFFF},
+    {"whitesmoke", 0xF5F5F5},
+    {"yellow", 0xFFFF00},
+    {"yellowgreen", 0x9ACD32},
+};
+
+} // namespace Util


### PR DESCRIPTION
Resolved #115 
1. Implement `Util::Color::` `FromRGB` , `FromHex`, `FromHSV`, `FromHSL`, `FromName` 
2. `FromHex` can use string as input,
3. Every API have default optional alpha value (default opaque) except `FromHex` 