### PR TITLE
Fix `.github/docs` can't access from doxygen page

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -920,7 +920,7 @@ WARN_LOGFILE           =
 INPUT                  = include
 INPUT                 += README.md
 # INPUT                 += CONTRIBUTING.md
-# INPUT                 += .github/docs
+INPUT                 += .github/docs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
```diff
+ INPUT += .github/docs
```