### PR TITLE
fix check config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,7 @@ jobs:
           build_dir: build
           exclude: lib
           split_workflow: true
+          config_file: .clang-tidy
         
       - name: Upload Result
         uses: ZedThree/clang-tidy-review/upload@v0.14.0


### PR DESCRIPTION
it seems like previously the `check.yml` workflow doesn't use our `.clang-tidy` file, this fixes it (hopefully)