### PR TITLE
Fix initialization of m_Pivot in GameObject.hpp

### DIFF
--- a/include/Util/GameObject.hpp
+++ b/include/Util/GameObject.hpp
@@ -160,7 +160,7 @@ protected:
 
     float m_ZIndex = 0;
     bool m_Visible = true;
-    glm::vec2 m_Pivot;
+    glm::vec2 m_Pivot = {0, 0};
 };
 } // namespace Util
 #endif


### PR DESCRIPTION
- resolved #169 

This pull request fixes the initialization of the m_Pivot variable in the GameObject.hpp file. Previously, the m_Pivot variable was not properly initialized, leading to potential bugs or unexpected behavior. With this fix, the m_Pivot variable is now initialized to {0, 0}, ensuring correct behavior in the code.