### PR TITLE
Fix Delta time & Delay

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ AllowShortFunctionsOnASingleLine: Inline
 AlwaysBreakTemplateDeclarations: Yes
 PackConstructorInitializers: Never
 InsertNewlineAtEOF: true
+BreakAfterAttributes: Always

--- a/example/src/Giraffe.cpp
+++ b/example/src/Giraffe.cpp
@@ -31,9 +31,9 @@ void Giraffe::Update() {
         dir.x *= -1;
     }
 
-    auto delta = static_cast<float>(Util::Time::GetDeltaTime());
+    auto delta = static_cast<float>(Util::Time::GetDeltaTimeMs());
     Util::Transform deltaTransform{
-        dir * delta * 1000.0F, 2 * delta,
+        dir * delta, 0.002F * delta,
         glm::vec2(1, 1) * (std::sin(rotation / 2) + 1.0F) * 100.0F};
 
     pos += deltaTransform.translation;

--- a/example/src/Giraffe.cpp
+++ b/example/src/Giraffe.cpp
@@ -31,7 +31,8 @@ void Giraffe::Update() {
         dir.x *= -1;
     }
 
-    auto delta = Util::Time::GetDeltaTimeMs();
+    // sonarcloud called it redundant, but ms_t = float is just a coincidence.
+    auto delta = static_cast<float>(Util::Time::GetDeltaTimeMs());
     Util::Transform deltaTransform{
         dir * delta, 0.002F * delta,
         glm::vec2(1, 1) * (std::sin(rotation / 2) + 1.0F) * 100.0F};

--- a/example/src/Giraffe.cpp
+++ b/example/src/Giraffe.cpp
@@ -31,7 +31,7 @@ void Giraffe::Update() {
         dir.x *= -1;
     }
 
-    auto delta = static_cast<float>(Util::Time::GetDeltaTimeMs());
+    auto delta = Util::Time::GetDeltaTimeMs();
     Util::Transform deltaTransform{
         dir * delta, 0.002F * delta,
         glm::vec2(1, 1) * (std::sin(rotation / 2) + 1.0F) * 100.0F};

--- a/example/src/GiraffeText.cpp
+++ b/example/src/GiraffeText.cpp
@@ -17,7 +17,8 @@ void GiraffeText::Update() {
                      2 * glm::pi<float>());
     ImGui::DragFloat2("Scale", &m_Transform.scale[0], 0.1F, 1, 10);
     ImGui::End();
-    m_Text->SetText(fmt::format("{:.02f}", 1.0F / Util::Time::GetDeltaTime()));
+    m_Text->SetText(
+        fmt::format("{:.02f}", 1000.0F / Util::Time::GetDeltaTimeMs()));
 
     m_Text->SetColor(Util::Color::FromName(Util::Colors::RED));
 }

--- a/include/Core/Context.hpp
+++ b/include/Core/Context.hpp
@@ -47,7 +47,7 @@ private:
     unsigned int m_WindowHeight = WINDOW_HEIGHT;
 
     // Can't access Time::s_Now, so using this variable to track time.
-    Util::ms_t m_before_update_time = Util::Time::GetElapsedTimeMs();
+    Util::ms_t m_BeforeUpdateTime = Util::Time::GetElapsedTimeMs();
 };
 
 } // namespace Core

--- a/include/Core/Context.hpp
+++ b/include/Core/Context.hpp
@@ -5,6 +5,8 @@
 
 #include "config.hpp"
 
+#include "Util/Time.hpp"
+
 namespace Core {
 class Context {
 public:
@@ -43,6 +45,9 @@ private:
 
     unsigned int m_WindowWidth = WINDOW_WIDTH;
     unsigned int m_WindowHeight = WINDOW_HEIGHT;
+
+    // Can't access Time::s_Now, so using this variable to track time.
+    Util::ms_t m_before_update_time = Util::Time::GetElapsedTimeMs();
 };
 
 } // namespace Core

--- a/include/Util/Time.hpp
+++ b/include/Util/Time.hpp
@@ -5,6 +5,9 @@
 
 namespace Util {
 
+using second_t = double;
+using ms_t = double;
+
 /**
  * @class Time
  * @brief A singleton class that provides time-related functionalities.
@@ -25,7 +28,7 @@ public:
      *
      * @return The delta time between frames in seconds.
      */
-    static double GetDeltaTime() { return s_DeltaTime; }
+    static second_t GetDeltaTime() { return s_DeltaTime; }
 
     /**
      * @brief Get the elapsed time from the start of the program in
@@ -36,7 +39,7 @@ public:
      *
      * @return The elapsed time from the start of the program in milliseconds.
      */
-    static unsigned long GetElapsedTimeMs();
+    static ms_t GetElapsedTimeMs();
 
     /**
      * @brief Update the time.
@@ -48,21 +51,21 @@ public:
     static void Update();
 
 private:
-    static unsigned long s_Start;
+    static Uint64 s_Start;
 
     /**
      * @brief The current time.
      *
      * This variable stores the current time.
      */
-    static unsigned long s_Now;
+    static Uint64 s_Now;
 
     /**
      * @brief The time of the last frame.
      *
      * This variable stores the time of the last frame.
      */
-    static unsigned long s_Last;
+    static Uint64 s_Last;
 
     /**
      * @brief The delta time between frames.
@@ -70,7 +73,7 @@ private:
      * This variable stores the time difference between the current frame and
      * the last frame.
      */
-    static double s_DeltaTime;
+    static second_t s_DeltaTime;
 };
 } // namespace Util
 

--- a/include/Util/Time.hpp
+++ b/include/Util/Time.hpp
@@ -5,8 +5,9 @@
 
 namespace Util {
 
-using second_t = double;
-using ms_t = double;
+using sdl_count_t = Uint64;
+using second_t = float;
+using ms_t = float;
 
 /**
  * @class Time
@@ -28,7 +29,20 @@ public:
      *
      * @return The delta time between frames in seconds.
      */
-    static second_t GetDeltaTime() { return s_DeltaTime; }
+    [[deprecated("Use GetDeltaTimeMs() instead.")]]
+    static second_t GetDeltaTime() {
+        return s_DeltaTime / 1000.0F;
+    }
+
+    /**
+     * @brief Get the delta time between frames in milliseconds.
+     *
+     * This function returns the time difference between the current frame and
+     * the last frame. The time difference is measured in milliseconds.
+     *
+     * @return The delta time between frames in milliseconds.
+     */
+    static ms_t GetDeltaTimeMs() { return s_DeltaTime; }
 
     /**
      * @brief Get the elapsed time from the start of the program in
@@ -51,21 +65,21 @@ public:
     static void Update();
 
 private:
-    static Uint64 s_Start;
+    static sdl_count_t s_Start;
 
     /**
      * @brief The current time.
      *
      * This variable stores the current time.
      */
-    static Uint64 s_Now;
+    static sdl_count_t s_Now;
 
     /**
      * @brief The time of the last frame.
      *
      * This variable stores the time of the last frame.
      */
-    static Uint64 s_Last;
+    static sdl_count_t s_Last;
 
     /**
      * @brief The delta time between frames.
@@ -73,7 +87,7 @@ private:
      * This variable stores the time difference between the current frame and
      * the last frame.
      */
-    static second_t s_DeltaTime;
+    static ms_t s_DeltaTime;
 };
 } // namespace Util
 

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -144,11 +144,11 @@ void Context::Update() {
     // # Updating/rendering time is denoted as "UT"
     Util::Time::Update();
 
-    Util::second_t deltaTime = Util::Time::GetDeltaTime();
+    auto deltaTime = Util::Time::GetDeltaTimeMs();
     LOG_DEBUG("Delta(Update+Delay): {:.1f}({:.1f}+{:.1f}) ms, FPS: {:.1f}",
-              deltaTime * 1000, update_time,
+              deltaTime , update_time,
               update_time < frameTime ? frameTime - update_time : 0,
-              1.0f / deltaTime);
+              1000.0f / deltaTime);
 }
 
 std::shared_ptr<Context> Context::GetInstance() {

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -124,8 +124,7 @@ void Context::Update() {
     SDL_GL_SwapWindow(m_Window);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    constexpr ms_t frameTime =
-        FPS_CAP != 0 ? 1000.0F / FPS_CAP : 0;
+    constexpr ms_t frameTime = FPS_CAP != 0 ? 1000.0F / FPS_CAP : 0;
     ms_t afterUpdate = Util::Time::GetElapsedTimeMs();
     ms_t updateTime = afterUpdate - m_BeforeUpdateTime;
     if (updateTime < frameTime) {

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -126,13 +126,14 @@ void Context::Update() {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     constexpr ms_t frameTime =
-        FPS_CAP != 0 ? 1000 / static_cast<double>(FPS_CAP) : 0;
-    ms_t after_update = Util::Time::GetElapsedTimeMs();
-    ms_t update_time = after_update - m_before_update_time;
-    if (update_time < frameTime) {
-        SDL_Delay(static_cast<Uint32>(frameTime - update_time));
+        FPS_CAP != 0 ? static_cast<float>(1000.0F / FPS_CAP) : 0;
+    ms_t afterUpdate = Util::Time::GetElapsedTimeMs();
+    ms_t updateTime = afterUpdate - m_BeforeUpdateTime;
+    if (updateTime < frameTime) {
+        // FIXME: SDL_Delay() accuracy issue
+        SDL_Delay(static_cast<Uint32>(frameTime - updateTime));
     }
-    m_before_update_time = Util::Time::GetElapsedTimeMs();
+    m_BeforeUpdateTime = Util::Time::GetElapsedTimeMs();
 
     // Here's a figure explaining how Delta time & Delay work:
     //
@@ -144,11 +145,13 @@ void Context::Update() {
     // # Updating/rendering time is denoted as "UT"
     Util::Time::Update();
 
+#ifdef DEBUG_DELTA_TIME
     auto deltaTime = Util::Time::GetDeltaTimeMs();
     LOG_DEBUG("Delta(Update+Delay): {:.1f}({:.1f}+{:.1f}) ms, FPS: {:.1f}",
-              deltaTime, update_time,
-              update_time < frameTime ? frameTime - update_time : 0,
+              deltaTime, updateTime,
+              updateTime < frameTime ? frameTime - updateTime : 0,
               1000.0f / deltaTime);
+#endif // DEBUG_DELTA_TIME
 }
 
 std::shared_ptr<Context> Context::GetInstance() {

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -125,7 +125,7 @@ void Context::Update() {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     constexpr ms_t frameTime =
-        FPS_CAP != 0 ? static_cast<float>(1000.0F / FPS_CAP) : 0;
+        FPS_CAP != 0 ? 1000.0F / FPS_CAP : 0;
     ms_t afterUpdate = Util::Time::GetElapsedTimeMs();
     ms_t updateTime = afterUpdate - m_BeforeUpdateTime;
     if (updateTime < frameTime) {

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -146,7 +146,7 @@ void Context::Update() {
 
     auto deltaTime = Util::Time::GetDeltaTimeMs();
     LOG_DEBUG("Delta(Update+Delay): {:.1f}({:.1f}+{:.1f}) ms, FPS: {:.1f}",
-              deltaTime , update_time,
+              deltaTime, update_time,
               update_time < frameTime ? frameTime - update_time : 0,
               1000.0f / deltaTime);
 }

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -120,7 +120,6 @@ void Context::Setup() {
 }
 
 void Context::Update() {
-    Util::Time::Update();
     Util::Input::Update();
     SDL_GL_SwapWindow(m_Window);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -130,7 +129,6 @@ void Context::Update() {
     ms_t afterUpdate = Util::Time::GetElapsedTimeMs();
     ms_t updateTime = afterUpdate - m_BeforeUpdateTime;
     if (updateTime < frameTime) {
-        // FIXME: SDL_Delay() accuracy issue
         SDL_Delay(static_cast<Uint32>(frameTime - updateTime));
     }
     m_BeforeUpdateTime = Util::Time::GetElapsedTimeMs();

--- a/src/Util/Animation.cpp
+++ b/src/Util/Animation.cpp
@@ -59,9 +59,9 @@ void Animation::Update() {
         return;
     }
 
-    m_TimeBetweenFrameUpdate += Util::Time::GetDeltaTime();
-    unsigned int updateFrameCount =
-        m_TimeBetweenFrameUpdate / (m_Interval / 1000);
+    m_TimeBetweenFrameUpdate += Util::Time::GetDeltaTimeMs();
+    auto updateFrameCount =
+        static_cast<unsigned int>(m_TimeBetweenFrameUpdate / m_Interval);
     if (updateFrameCount <= 0)
         return;
 

--- a/src/Util/Time.cpp
+++ b/src/Util/Time.cpp
@@ -2,22 +2,26 @@
 
 #include <SDL.h>
 
-Util::Time Time(); // static lifetime object
+namespace Util {
 
-unsigned long Util::Time::GetElapsedTimeMs() {
-    return 1000 * (SDL_GetPerformanceCounter() - s_Start) /
+Time Time(); // static lifetime object
+
+ms_t Time::GetElapsedTimeMs() {
+    return static_cast<ms_t>(1000 * (SDL_GetPerformanceCounter() - s_Start)) /
            (SDL_GetPerformanceFrequency());
 }
 
-void Util::Time::Update() {
+void Time::Update() {
     s_Last = s_Now;
-    s_Now = static_cast<unsigned long>(SDL_GetPerformanceCounter());
+    s_Now = SDL_GetPerformanceCounter();
 
     s_DeltaTime = static_cast<double>(s_Now - s_Last) /
                   static_cast<double>(SDL_GetPerformanceFrequency());
 }
 
-unsigned long Util::Time::s_Start = SDL_GetPerformanceCounter();
-unsigned long Util::Time::s_Now = SDL_GetPerformanceCounter();
-unsigned long Util::Time::s_Last = 0;
-double Util::Time::s_DeltaTime = 0;
+Uint64 Time::s_Start = SDL_GetPerformanceCounter();
+Uint64 Time::s_Now = SDL_GetPerformanceCounter();
+Uint64 Time::s_Last = 0;
+second_t Time::s_DeltaTime = 0;
+
+} // namespace Util

--- a/src/Util/Time.cpp
+++ b/src/Util/Time.cpp
@@ -4,24 +4,22 @@
 
 namespace Util {
 
-Time Time(); // static lifetime object
-
 ms_t Time::GetElapsedTimeMs() {
-    return static_cast<ms_t>(1000 * (SDL_GetPerformanceCounter() - s_Start)) /
-           (SDL_GetPerformanceFrequency());
+    return static_cast<float>(SDL_GetPerformanceCounter() - s_Start) /
+           static_cast<float>((SDL_GetPerformanceFrequency())) * 1000.0F;
 }
 
 void Time::Update() {
     s_Last = s_Now;
     s_Now = SDL_GetPerformanceCounter();
 
-    s_DeltaTime = static_cast<double>(s_Now - s_Last) /
-                  static_cast<double>(SDL_GetPerformanceFrequency());
+    s_DeltaTime = static_cast<float>(s_Now - s_Last) /
+                  static_cast<float>(SDL_GetPerformanceFrequency()) * 1000.0F;
 }
 
-Uint64 Time::s_Start = SDL_GetPerformanceCounter();
-Uint64 Time::s_Now = SDL_GetPerformanceCounter();
-Uint64 Time::s_Last = 0;
-second_t Time::s_DeltaTime = 0;
+sdl_count_t Time::s_Start = SDL_GetPerformanceCounter();
+sdl_count_t Time::s_Now = Time::s_Start;
+sdl_count_t Time::s_Last = 0;
+ms_t Time::s_DeltaTime = 0;
 
 } // namespace Util


### PR DESCRIPTION
### About delta time issue
#### Original
>Delay time (Frame time - Delta time) is also incorrect, but I haven't figured out how to mark it on the diagram.
```
--|--Delay--|--UT--|--Delay--|--UT--|--
  |---Delta time---|            ^ Last delta time used here
  ^                ^
  (s_Last)         (s_Now) Time::Update here
```
#### After this PR (this diagram is recorded next to the implement)
```
--|--Delay--|--UT--|--Delay--|--UT--|--
            |---Delta time---|  ^ Last delta time used here
            ^                ^
            (s_Last)         (s_Now) Time::Update here
```
###### Updating/rendering time is denoted as "UT"

### Minor Changes

- Add `Util::Time`-related types `second_t`(`double`) & `ms_t`(`double`)
- `GetElapsedTimeMs()` used to return `unsigned long`, but now it returns `ms_t`
p.s. I'm not sure why it was designed this way.
- Variables (in `Util:Time`) related to SDL used to be `unsigned long`, but now they are `Uint64`, consistent with the SDL function declaration

#### Related issues
- Fix #167 