### PR TITLE
Fix window icon memory leak and add error handling

### DIFF
--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -163,7 +163,11 @@ std::shared_ptr<Context> Context::GetInstance() {
 
 void Context::SetWindowIcon(const std::string &path) {
     SDL_Surface *image = IMG_Load(path.c_str());
-    SDL_SetWindowIcon(m_Window, image);
-    SDL_FreeSurface(image);
+    if (image) {
+        SDL_SetWindowIcon(m_Window, image);
+        SDL_FreeSurface(image);
+        return;
+    }
+    LOG_ERROR("Failed to load image: {}", path);
 }
 } // namespace Core

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -164,5 +164,6 @@ std::shared_ptr<Context> Context::GetInstance() {
 void Context::SetWindowIcon(const std::string &path) {
     SDL_Surface *image = IMG_Load(path.c_str());
     SDL_SetWindowIcon(m_Window, image);
+    SDL_FreeSurface(image);
 }
 } // namespace Core


### PR DESCRIPTION
This pull request fixes a memory leak in the `SetWindowIcon` function by freeing the SDL surface after setting the window icon. Additionally, it adds error handling for failed image loading in the same function.

before:
```sh
valgrind --leak-check=full --show-leak-kinds=all --verbose ./Example
```
![image](https://github.com/ntut-open-source-club/practical-tools-for-simple-design/assets/25154413/83b9f789-e1d1-4421-a18d-616be50cf59c)
![image](https://github.com/ntut-open-source-club/practical-tools-for-simple-design/assets/25154413/f9830394-09d4-46eb-a8d0-48bbd7f96cda)
