### PR TITLE
fix m_BeforeUpdateTime produces garbage on first loop

### DIFF
--- a/include/Core/Context.hpp
+++ b/include/Core/Context.hpp
@@ -47,7 +47,7 @@ private:
     unsigned int m_WindowHeight = PTSD_Config::WINDOW_HEIGHT;
 
     // Can't access Time::s_Now, so using this variable to track time.
-    Util::ms_t m_BeforeUpdateTime = Util::Time::GetElapsedTimeMs();
+    Util::ms_t m_BeforeUpdateTime = 0;
 };
 } // namespace Core
 


### PR DESCRIPTION
the original implementation calls `SDL_` functions before `SDL_init` is called, which probably produces garbage results on first loop on some environments (Linux?)

and on
https://github.com/ntut-open-source-club/practical-tools-for-simple-design/blob/28669352a5bd8466a8d0b34de816c2935c3dfab5/src/Core/Context.cpp#L131-L135
`updateTime` can be a large negative number, causing `SDL_Delay` to sleep for a very long time